### PR TITLE
Add tl::expected library dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -86,6 +86,14 @@ new_git_repository(
 )
 
 http_archive(
+    name = "expected",
+    build_file = "@//thirdparty/expected:BUILD.external",
+    sha256 = "8f5124085a124113e75e3890b4e923e3a4de5b26a973b891b3deb40e19c03cee",
+    strip_prefix = "expected-1.0.0",
+    url = "https://github.com/TartanLlama/expected/archive/v1.0.0.tar.gz",
+)
+
+http_archive(
     name = "rocksdb",
     build_file = "@//thirdparty/rocksdb:BUILD.external",
     sha256 = "c6502c7aae641b7e20fafa6c2b92273d935d2b7b2707135ebd9a67b092169dca",

--- a/thirdparty/expected/BUILD.external
+++ b/thirdparty/expected/BUILD.external
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v.2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+cc_library(
+    name = "expected",
+    hdrs = ["tl/expected.h"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "header_mv",
+    srcs = ["include/tl/expected.hpp"],
+    outs = ["tl/expected.h"],
+    cmd  = "mkdir tl && mv $(location include/tl/expected.hpp) $(location tl/expected.h)",
+)


### PR DESCRIPTION
Expected is a preferable way to handle errors which is more akin to
Go error handling. It's seemingly close to being in std:: but not yet
tl:: has a similar implementation that we can use.