### PR TITLE
Fix create space in REPL

### DIFF
--- a/client/repl.py
+++ b/client/repl.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
         space = tokens[1]
         key = tokens[2]
         if cmd == "create":
-            client.create_space(space, key)
+            client.create_space(space, int(key))
             print("SUCCESS")
         elif cmd == "get":
             print(client.get(space, key))


### PR DESCRIPTION
It wasn't casting the string input to an int, so it was failing.